### PR TITLE
fixed test_reversed()

### DIFF
--- a/practice/practice_1.2/test_linked_list.py
+++ b/practice/practice_1.2/test_linked_list.py
@@ -274,6 +274,6 @@ class TestLinkedList(unittest.TestCase):
             linked_list = create_linked_list(list(range(i)))
             with self.subTest(node_list=list(range(i))):
                 self.assertEqual(
-                    [item.data for item in reversed(linked_list)],
+                    [item for item in reversed(linked_list)],
                     list(range(i - 1, -1, -1))
                 )


### PR DESCRIPTION
Баг в test_reversed():
277 -> [item.data for item in reversed(linked_list)], Fixed:
277 -> [item for item in reversed(linked_list)],

Вызов item.data вернёт AttributeError, так как используемый __getitem__() уже возвращает атрибут data, а не экземпляр класса LinkedListItem (см. test_getitem())